### PR TITLE
Sundry licensing cleanups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,0 @@
-Conditions for Contributions to Whonix are not part of Whonix's license.
-
-Any changes you pull into this source will be also licensed under GPL v3 or any
-later. Additionally you grant ENCRYPTED SUPPORT LP the right to re-license your
-work under a different license. If that is not acceptable, you can either fork
-this source under GPL v3 or any later or contact ENCRYPTED SUPPORT LP. Contact
-ENCRYPTED SUPPORT LP, if you require this source code under different license.

--- a/COPYING
+++ b/COPYING
@@ -2,6 +2,7 @@ Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
 Copyright: 2012 - 2018 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+Copyright: 2018 Freedom of the Press Foundation <securedrop@freedom.press>
 License: GPL-3+
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Removes CONTRIBUTING.md, which was explicitly referencing Whonix, which
would likely be confusing to future contributors. Also adds a line for
FPF and the SecureDrop Team contact info to the COPYING file.