### PR TITLE
Add securedrop-workstation-config package to template

### DIFF
--- a/securedrop-workstation.conf
+++ b/securedrop-workstation.conf
@@ -7,10 +7,11 @@
 # Assigments can be made with VAR_NAME="VALUE"
 
 GIT_URL_template_securedrop_workstation = https://github.com/freedomofpress/qubes-template-securedrop-workstation
+
 BRANCH_template_securedrop_workstation ?= master
 BUILDER_PLUGINS += builder-debian
 BUILDER_PLUGINS += template-securedrop-workstation
-
+USE_QUBES_REPO_VERSION = 4.0
 # TEMPLATE_ONLY - Only build templates
 # Set 1 to only build template or clear the value for a full build
 # Default: novalue

--- a/securedrop-workstation/04_install_qubes_post.sh
+++ b/securedrop-workstation/04_install_qubes_post.sh
@@ -52,7 +52,7 @@ echo "$workstation_repository_apt_line" > "${INSTALLDIR}/$workstation_repository
 
 aptUpdate
 
-aptInstall securedrop-workstation-grsec
+aptInstall securedrop-workstation-grsec securedrop-workstation-config
 
 # Needed for qubes tooling (qubes-open-in-vm and qubes-copy-to-vm)
 # If more pax flags are needed in the future, we should manage them through a config file


### PR DESCRIPTION
Metapackage to install packages and configuration for the base template
use for securedrop-workstation. This package can be found in the https://github.com/freedomofpress/securedrop-debian-packaging repo.

Testing instructions (we could definitely improve the dev/testing story by adding another makefile target):
* in `securedrop-workstation`, run make template (you can cancel once the image starts building, the purpose is just to download the sources and bootstrap the dev env)
*Apply changes in builder/qubes-builder/qubes-src/template-securedrop-workstation/: checkout this branch and `cp securedrop-workstation.conf ../builder.conf`
* In builder/qubes-builder: make qubes-vm && make-template
* Copy template to dom0 and install it
* `qvm-prefs securedrop-workstation kernel ''`
* `qvm-prefs securedrop-workstation virt_mode hvm`
* start the VM or create an appvm on this template and start that vm, open a terminal window
* apt list --installed contains `securedrop-workstation-config` and `securedrop-workstation-grsec`