### PR TITLE
Bumps release marker 4 -> 4.0

### DIFF
--- a/securedrop-workstation.conf
+++ b/securedrop-workstation.conf
@@ -20,7 +20,7 @@ TEMPLATE_ONLY ?= 1
 # 2 - Release 2
 # 3 - Release 3
 # Default: 3
-RELEASE := 4
+RELEASE := 4.0
 
 DISTS_VM :=
 DISTS_VM += securedrop-workstation


### PR DESCRIPTION
Small change required for compatibility with upstream builder changes.
Unblocks working TemplateVM builds for the `securedrop-workstation`
template.

Proposed test plan

- Clone the `qubes-builder` repository
- Clone `qubes-template-securedrop-workstation` in `qubes-builder/qubes-src` and copy `securedrop-workstation.conf` as `builder.conf in the qubes-builder repo root
- `make install-deps`
- `make get-sources`
-  check out this branch and copy the newly updated `securedrop-workstation.conf` as `builder.conf in the qubes-builder repo root
- `make qubes-vm`
-  `make template`
-  copy the template to dom0: `qvm-run --pass-io $BUILDER_DOMAIN 'cat /path/to/rpm'> template.rpm`
- rpm -i template.rpm
- in dom0: `qvm-prefs securedrop-workstation virt-mode hvm` and `qvm-prefs securedrop-workstation kernel ''`
- [ ] The securedrop-workstation vm boots and is running a grsec kernel (`uname -r`)
