### PR TITLE
Update template build logic to use debian10-buster

### DIFF
--- a/builder.conf
+++ b/builder.conf
@@ -30,7 +30,7 @@ endif
 # include some other TEMPLATE_FLAVORs.  A TEMPLATE_LABEL will automatically
 # be created if one does not exist that will use the alias name as the
 # template name.  Plus signs (+) will be converted to hyphens (-).
-TEMPLATE_ALIAS += securedrop-workstation:stretch+securedrop-workstation
+TEMPLATE_ALIAS += securedrop-workstation:buster+securedrop-workstation
 
 ################################################################################
 #                 T E M P L A T E   C O N F I G U R A T I O N
@@ -39,7 +39,7 @@ TEMPLATE_ALIAS += securedrop-workstation:stretch+securedrop-workstation
 # of 31 characters for the final template name
 #
 # TEMPLATE_LABEL += <DIST_VM name as listed above>:<desired final template name>
-TEMPLATE_LABEL += stretch+securedrop-workstation:securedrop-workstation
+TEMPLATE_LABEL += buster+securedrop-workstation:securedrop-workstation
 
 $(strip $(foreach _alias, $(TEMPLATE_ALIAS), $(_aliases)))
 

--- a/builder.conf
+++ b/builder.conf
@@ -39,7 +39,7 @@ TEMPLATE_ALIAS += securedrop-workstation:buster+securedrop-workstation
 # of 31 characters for the final template name
 #
 # TEMPLATE_LABEL += <DIST_VM name as listed above>:<desired final template name>
-TEMPLATE_LABEL += buster+securedrop-workstation:securedrop-workstation
+TEMPLATE_LABEL += buster+securedrop-workstation:securedrop-workstation-buster
 
 $(strip $(foreach _alias, $(TEMPLATE_ALIAS), $(_aliases)))
 

--- a/securedrop-workstation/04_install_qubes_post.sh
+++ b/securedrop-workstation/04_install_qubes_post.sh
@@ -35,7 +35,7 @@ mount --bind /dev "${INSTALLDIR}/dev"
 
 aptInstall apt-transport-https
 
-[ -n "$workstation_repository_suite" ] || workstation_repository_suite="stretch"
+[ -n "$workstation_repository_suite" ] || workstation_repository_suite="buster"
 [ -n "$workstation_signing_key_fingerprint" ] || workstation_signing_key_fingerprint="4ED79CC3362D7D12837046024A3BE4A92211B03C"
 [ -n "$workstation_signing_key_file" ] || workstation_signing_key_file="$BUILDER_DIR/$SRC_DIR/template-securedrop-workstation/keys/apt-test.asc"
 [ -n "$gpg_keyserver" ] || gpg_keyserver="keys.gnupg.net"


### PR DESCRIPTION
Closes https://github.com/freedomofpress/securedrop-workstation/issues/308

### Background
- Kernel configuration / build logic : https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/51
- Packages for buster channel needed for build logic, including kernel images, headers, and metapackages, as well as config metapackages: https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/22
### Test plan:
- Create (or repurpose) a fedora-based Qube with at least 20GB of private storage
- Check out securedrop-workstation's master branch
- apply the following diff (this is for testing only, to make testing easier and to avoid the manual build steps)
```
diff --git a/builder/build-workstation-template b/builder/build-workstation-template
index 103ae03..eb5323e 100755
--- a/builder/build-workstation-template
+++ b/builder/build-workstation-template
@@ -24,7 +24,7 @@ fi
 rm -rf "${qubes_builder_dir}" "${sd_template_dir}"
 
 git clone https://github.com/qubesos/qubes-builder "${build_dir}/qubes-builder"
-git clone https://github.com/freedomofpress/qubes-template-securedrop-workstation "${sd_template_dir}"
+git clone -b debian-buster https://github.com/freedomofpress/qubes-template-securedrop-workstation "${sd_template_dir}"
 
 cd "${qubes_builder_dir}"
```
- [ ] make template completes without error (this should take 20-30 minutes depending on internet speed)
- Copy the built template into dom0 (the template is in `securedrop-workstation/builder/qubes-builder/qubes-src/rpmbuild/rpm/noarch`)
- install the template in dom0
- [ ] template installs successfully in dom0
- Run `qvm-prefs securedrop-workstation-buster virt_mode hvm`
- Run `qvm-prefs securedrop-workstation-buster kernel ""`
- [ ] The templateVM boots, and `uname -r` returns `4.14.151-grsec`
- [ ] The name of the template makes sense (it was purposely _not_ named `securedrop-worksation` so that this template can coexist happily with `securedrop-workstation` template
### pre merge
Before merging, please revert commit 250f989 which was introduced for testing only
### post merge:
- push a signed tag pointing to master's HEAD with the FPF Authority Key
250f989 
