### PR TITLE
Use main as default branch

### DIFF
--- a/securedrop-workstation.conf
+++ b/securedrop-workstation.conf
@@ -8,7 +8,7 @@
 
 GIT_URL_template_securedrop_workstation = https://github.com/freedomofpress/qubes-template-securedrop-workstation
 
-BRANCH_template_securedrop_workstation ?= master
+BRANCH_template_securedrop_workstation ?= main
 BUILDER_PLUGINS += builder-debian
 BUILDER_PLUGINS += template-securedrop-workstation
 USE_QUBES_REPO_VERSION = 4.0


### PR DESCRIPTION
After merge, this will require a tag signature

This unfortunately cannot effectively be tested: the test plan would require replacing the value `BRANCH_template_securedrop_workstation` with this feature branch

Main has already been set as the default branch for this repository