### PR TITLE
Docs and builder updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+qubes-builder/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,8 @@
+DEFAULT_GOAL: help
+
 template: ## Automatically build template RPM
 	./build-workstation-template
 
-# Explanation of the below shell command should it ever break.
-# 1. Set the field separator to ": ##" to parse lines for make targets.
-# 2. Check for second field matching, skip otherwise.
-# 3. Print fields 1 and 2 with colorized output.
-# 4. Sort the list of make targets alphabetically
-# 5. Format columns with colon as delimiter.
 .PHONY: help
 help: ## Prints this message and exits
 	@printf "Makefile for developing and testing SecureDrop Workstation.\n"

--- a/README.md
+++ b/README.md
@@ -2,34 +2,55 @@
 
 # qubes-template-securedrop-workstation
 
-This work was inspired by and reuses code from the Whonix Qubes template: https://github.com/adrelanos/qubes-template-whonix
-It is a derivative work under the GPL license, version 3 (see the files `COPYING` and `GPLv3` for details)
-
+Repository for managing the TemplateVM RPM used by the [SecureDrop Workstation] in provisioning custom VMs.
 
 ## Build instructions
 
-Note that these instructions must be carried out on a Fedora-based Qubes VM. Building templates uses a substantial amount of disk space.
+Note that these instructions must be carried out on a Fedora-based Qubes VM.
+Building templates uses a substantial amount of disk space.
 
 ### Set up build VM:
-1. Create a fedora-31 based AppVM for building the templates
-2. Increase the disk size to at least 20GB (as the build uses over 10GB): qvm-volume extend sd-template-builder:private 15GB (if your VM is not named sd-template-builder, adjust that command)
-3. Import the QubesOS master key and the GPG key used to sign tags (see https://www.qubes-os.org/security/verifying-signatures/)
+Set up a long-lived VM that you can use for building SDW templates.
+You'll only need to perform this step once, although make sure to check
+whether your Fedora version remains current.
+
+1. Create an AppVM based on the most recent fedora release: `qvm-create --label purple --template fedora-33 sd-template-builder`
+2. Increase the disk size to at least 20GB (as the build uses over 10GB): `qvm-volume resize sd-template-builder:private 20G`
+3. Clone this repository into the AppVM: `git clone https://github.com/freedomofpress/qubes-template-securedrop-workstation`
 
 ### Automatic build
+We maintain a wrapper script that handles the interoperation with the upstream [qubes-builder] logic.
+Typically, you'll need only this short-and-sweet workflow to build a new template RPM.
+If you encounter problems, see the manual build instructions below.
 
 1. `make template`
-2. The Template RPM can be found in ./qubes-builder/qubes-src/linux-template-builder/rpm/
+2. The Template RPM can be found in `./qubes-builder/qubes-src/linux-template-builder/rpm/`
 
 ### Testing changes to builder logic
 
-1. Repace the following value in `securedrop-workstation.conf`: ` BRANCH_template_securedrop_workstation ?= $TEST_BRANCH`
-2. Sign the tag using a trusted key (or edit the `builder/build-workstation-template` script to import/trust the key)
-3. `make template`
+The qubes-builder logic expects signed tags on the most recent HEAD commit of the target branch.
+If you're making changes to the build logic in this repo, you won't have a prod-signed tag yet,
+since you're still testing! Create a test-only tag signed with your individual GPG key.
+
+0. Make the changes you intend to test on a branch of this repo.
+1. Edit `securedrop-workstation.conf` and set ` BRANCH_template_securedrop_workstation ?= <YOUR_BRANCH_NAME>`
+2. Edit `build-workstation-template` to include your individual fingerprint, so the tag can be verified
+3. Create a signed tag on that branch: `git tag -s $(date +%Y%m%d-test)`, and push to the remote
+4. `make template`
+
+As your make changes to the feature branch, you must update or replace the signed git tags, so that HEAD remains signed.
+There are settings such as `LESS_SECURE_SIGNED_COMMITS_SUFFICIENT` for the `builder.conf`, which may be useful for testing.
 
 ### Manual build
 
-1. Import and trust the [Qubes Master Key](https://www.qubes-os.org/security/verifying-signatures/) and the FPF authority key into your gpg keyring or GPG domain's keyring
-2. Clone the [qubes-builder repository](https://github.com/qubesos/qubes-builder)
+The wrapper script can get out of sync with the qubes-builder logic (which isn't pinned via submodule,
+see [relevant issue](https://github.com/freedomofpress/qubes-template-securedrop-workstation/issues/14)).
+If that happens, run through the steps manually. The steps below closely mirror the script logic within
+`build-workstation-template`, so compare with the latest there.
+
+1. Import and trust the [Qubes Master Key](https://www.qubes-os.org/security/verifying-signatures/)
+   and the SecureDrop Release Signing Key to the local gpg keyring in your `sd-template-builder` AppVM.
+2. Clone the [qubes-builder] repository
 3. Change directories into the `qubes-builder` repo
 4. Copy the `securedrop-workstation.conf` from this repo as `builder.conf` inside the `qubes-builder` repo
 5. `make about` should return `securedrop-workstation.conf`
@@ -44,12 +65,20 @@ Note that these instructions must be carried out on a Fedora-based Qubes VM. Bui
 1. Copy the template to dom0:
 
 ```
-qvm-run --pass-io work 'cat source/file/location' > destination/<file>.rpm
-sudo rpm -i <file>.rpm
+qvm-run --pass-io sd-template-builder 'cat source/file/location' > destination/sdw.rpm
+sudo dnf install sdw.rpm
 ```
 
 2. Create a VM based on this template for testing:
 
 ```
-qvm-create --template securedrop-workstation test-securedrop-workstation --class AppVM --property virt_mode=hvm --property kernel='' --label green
+qvm-create --template securedrop-workstation-buster test-sdw-buster --class AppVM --property virt_mode=hvm --property kernel='' --label green
 ```
+
+## Acknowledgments
+This work was inspired by and reuses code from the Whonix Qubes template: https://github.com/adrelanos/qubes-template-whonix
+It is a derivative work under the GPL license, version 3 (see the files `COPYING` and `GPLv3` for details)
+
+
+[SecureDrop Workstation]: https://github.com/freedomofpress/securedrop-workstation
+[qubes-builder]: https://github.com/qubesos/qubes-builder

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ Building templates uses a substantial amount of disk space.
 
 ### Set up build VM:
 Set up a long-lived VM that you can use for building SDW templates.
-You'll only need to perform this step once, although make sure to check
-whether your Fedora version remains current.
+This should be a separate VM from the (Debian-based) `sd-dev` recommended
+in the [SDW setup docs](https://github.com/freedomofpress/securedrop-workstation/#development-environment).
+You'll only need to perform this step once, although you should confirm
+whether your Fedora version remains current each time.
 
-1. Create an AppVM based on the most recent fedora release: `qvm-create --label purple --template fedora-33 sd-template-builder`
+1. Create an AppVM based on the most recent fedora release: `qvm-create --label purple --template fedora-XX sd-template-builder`
 2. Increase the disk size to at least 20GB (as the build uses over 10GB): `qvm-volume resize sd-template-builder:private 20G`
 3. Clone this repository into the AppVM: `git clone https://github.com/freedomofpress/qubes-template-securedrop-workstation`
 
@@ -23,12 +25,15 @@ We maintain a wrapper script that handles the interoperation with the upstream [
 Typically, you'll need only this short-and-sweet workflow to build a new template RPM.
 If you encounter problems, see the manual build instructions below.
 
-1. `make template`
-2. The Template RPM can be found in `./qubes-builder/qubes-src/linux-template-builder/rpm/`
+1. Run `sudo dnf upgrade -y` to ensure your machine is up to date.
+2. `make template`
+3. The Template RPM can be found in `./qubes-builder/qubes-src/linux-template-builder/rpm/`
 
 ### Testing changes to builder logic
 
 The qubes-builder logic expects signed tags on the most recent HEAD commit of the target branch.
+The tag and commit must be present on the _remote_, i.e. this repository. Simply creating them
+locally isn't enough, you'll need to push them up to the remote.
 If you're making changes to the build logic in this repo, you won't have a prod-signed tag yet,
 since you're still testing! Create a test-only tag signed with your individual GPG key.
 

--- a/build-workstation-template
+++ b/build-workstation-template
@@ -19,6 +19,10 @@ then
     make -C "${qubes_builder_dir}" clean-chroot
 fi
 
+# Dump platform info, useful for build logs
+echo "Platform info:"
+hostnamectl
+
 # Heavy-handed, but ensures build is clean, and also sidesteps idempotence
 # issues with the git clone/checkout commands.
 rm -rf "${qubes_builder_dir}"

--- a/build-workstation-template
+++ b/build-workstation-template
@@ -10,6 +10,7 @@ repo_root="$(git rev-parse --show-toplevel)"
 build_dir="${repo_root}"
 qubes_builder_dir="${build_dir}/qubes-builder"
 gpg_homedir="${repo_root}/qubes-builder/keyrings/git"
+gpg_homedir_sdw="${gpg_homedir}/template-securedrop-workstation"
 
 # Chroot may exist due to previous failed build; let's clean up responsibly.
 if [[ -d "${qubes_builder_dir}" ]]
@@ -28,17 +29,24 @@ git clone https://github.com/qubesos/qubes-builder "${build_dir}/qubes-builder"
 cd "${qubes_builder_dir}"
 
 # Provision securedrop-workstation config so that we get the correct sources via `make get-sources`.
-cp ${repo_root}/securedrop-workstation.conf builder.conf
+cp "${repo_root}/securedrop-workstation.conf" builder.conf
 
 # Get sources for only the builder component, which will get Qubes dev keys and initialize the keyring
 make COMPONENTS="builder" get-sources
+mkdir -m 700 "${gpg_homedir_sdw}"
 
-# Add signing key to the keyring. The pubkey fingerprint tracked here is the "FPF Authority Key".
+# Add signing key to the keyring. The pubkey fingerprint tracked here is the SecureDrop
+# Release Signing Key. Temporarily, we'll authorize use of two signing keys, for rotation.
 # In order to test PRs, you may want to use a personal key with a temporary signed tag.
-# See comments above regarding feature branches in the git clone operation.
-release_key_fingerprint="22245C81E3BAEB4138B36061310F561200F4AD77"
-gpg --homedir ${gpg_homedir} --keyserver keys.openpgp.org --recv-key "$release_key_fingerprint"
-echo "${release_key_fingerprint}:6:" | gpg --homedir ${gpg_homedir} --import-ownertrust
+# See README regarding feature branches for testing changes.
+release_key_fingerprint_2020="22245C81E3BAEB4138B36061310F561200F4AD77"
+release_key_fingerprint_2021="2359E6538C0613E652955E6C188EDD3B7B22E6A3"
+for k in "$release_key_fingerprint_2020" "$release_key_fingerprint_2021"; do
+    for d in "$gpg_homedir" "$gpg_homedir_sdw"; do
+        gpg --homedir "$d" --keyserver keys.openpgp.org --recv-key "$k"
+        echo "${k}:6:" | gpg --homedir "$d" --import-ownertrust
+    done
+done
 
 # Get all sources
 make get-sources


### PR DESCRIPTION
Two changes here:

* Significant README edits, with an eye toward maintainability (docs-only)
* Adds support for secondary component-specific keyring (effectively resolving the problem reported in https://github.com/freedomofpress/qubes-template-securedrop-workstation/issues/20#issuecomment-853345517)

### Testing
1. Use the new README presented here to configure a build VM on Qubes OS.
2. Attempt a test-only RPM build by following those docs. Remember that you'll have to:
    1. Branch _from_ this branch, committing changes to your feature branch
    2. Tag-and-sign your feature branch
    3. Run `make template`
    
The goal of the review is simply to emit an RPM for the TemplateVM (and ideally test that in dom0). Actually building a prod-ready artifact is out of scope for this issue, we'll follow up with a signed tag and build again post-merge, in order to satisfy #20.
    
Give that a whirl, and let me know if anything is unclear!
  
 