### PR TITLE
Remove unnecessary addition to paxctld.conf

### DIFF
--- a/securedrop-workstation/04_install_qubes_post.sh
+++ b/securedrop-workstation/04_install_qubes_post.sh
@@ -59,10 +59,6 @@ aptUpdate
 
 aptInstall securedrop-workstation-grsec securedrop-workstation-config securedrop-keyring
 
-# Needed for qubes tooling (qubes-open-in-vm and qubes-copy-to-vm)
-# If more pax flags are needed in the future, we should manage them through a config file
-$chroot_cmd sh -c 'echo "/usr/lib/gnome-terminal/gnome-terminal-server   m" >> /etc/paxctld.conf'
-
 ## Workaround for Qubes bug:
 ## 'Debian Template: rely on existing tool for base image creation'
 ## https://github.com/QubesOS/qubes-issues/issues/1055


### PR DESCRIPTION
1. This line doesn't make it into the running VMs because it gets clobbered by securedrop-workstation-config's paxctld.conf.
2. The file is now located at `/usr/libexec/gnome-terminal-server`.
3. Running gnome-terminal inside sd-app works perfectly fine, and looking at the `gnome-terminal-server` systemd service shows it is running as well.
4. Both `qvm-copy-to-vm` (e.g. proxy to app) and `qvm-open-in-dvm` (e.g. from app) work fine.

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/272.